### PR TITLE
support for mongoid with moped 2.0.x

### DIFF
--- a/lib/mongoid-audit/rails_admin.rb
+++ b/lib/mongoid-audit/rails_admin.rb
@@ -9,7 +9,7 @@ module RailsAdmin
         def message
           @message = @version.action
           mods = @version.modified.to_a.map do |c|
-            if c[1].class.name == "Moped::BSON::Binary"
+            if c[1].class.name == "BSON::Binary"
               c[0] + " = {binary data}"
             elsif c[1].to_s.length > 220
               c[0] + " = " + c[1].to_s[0..200]


### PR DESCRIPTION
Moped 2.x will be dropping the Moped namespace in favor of using the BSON gem directly. You may want to version, or branch this repo, but though i'd mention it and make the commit.
